### PR TITLE
feat(agent): add AGENTS.md support

### DIFF
--- a/tools/agent/CMakeLists.txt
+++ b/tools/agent/CMakeLists.txt
@@ -6,6 +6,7 @@ set(AGENT_SOURCES
     tool-registry.cpp
     permission.cpp
     skills/skills-manager.cpp
+    agents-md/agents-md-manager.cpp
     tools/tool-bash.cpp
     tools/tool-read.cpp
     tools/tool-write.cpp

--- a/tools/agent/README.md
+++ b/tools/agent/README.md
@@ -80,6 +80,7 @@ Replaced "old code" with "fixed code"
 | `/clear` | Clear conversation history |
 | `/tools` | List available tools |
 | `/skills` | List available skills |
+| `/agents` | List discovered AGENTS.md files |
 
 ## Skills
 
@@ -155,6 +156,64 @@ Skills are discovered from (in priority order):
 
 This "progressive disclosure" keeps context lean - only activated skills consume tokens.
 
+## AGENTS.md Support
+
+The agent automatically discovers and loads [AGENTS.md](https://agents.md) files, which provide project-specific guidance for AI coding assistants.
+
+### How It Works
+
+1. **Discovery**: At startup, the agent searches from the working directory up to the git root for `AGENTS.md` files, plus a global file
+2. **Precedence**: Files closer to the working directory take precedence (useful for monorepos). Global file has lowest precedence.
+3. **Injection**: Content is loaded into the system prompt, giving the agent project-specific context
+
+### Search Locations (in precedence order)
+
+1. `./AGENTS.md` - Current working directory (highest precedence)
+2. `../AGENTS.md`, `../../AGENTS.md`, ... - Parent directories up to git root
+3. `~/.config/llama-agent/AGENTS.md` - Global user preferences (lowest precedence)
+
+### Creating an AGENTS.md File
+
+Create an `AGENTS.md` file in your repository root:
+
+```markdown
+# Project Guidelines
+
+## Build & Test
+- Build: `cmake -B build && cmake --build build`
+- Test: `ctest --test-dir build`
+
+## Code Style
+- Use 4-space indentation
+- Follow Google C++ style guide
+
+## PR Guidelines
+- Include tests for new features
+- Update documentation
+```
+
+### Monorepo Support
+
+In monorepos, you can have nested `AGENTS.md` files:
+
+```
+repo/
+├── AGENTS.md           # General project guidance
+├── packages/
+│   ├── frontend/
+│   │   └── AGENTS.md   # Frontend-specific guidance (takes precedence)
+│   └── backend/
+│       └── AGENTS.md   # Backend-specific guidance
+```
+
+When working in `packages/frontend/`, both `AGENTS.md` files are loaded, with the frontend one taking precedence.
+
+### CLI Options
+
+| Flag | Description |
+|------|-------------|
+| `--no-agents-md` | Disable AGENTS.md discovery |
+
 ## MCP Server Support
 
 The agent supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, allowing you to extend its capabilities with external tools.
@@ -228,6 +287,7 @@ When prompted: `y` (yes), `n` (no), `a` (always allow), `d` (deny always)
 | `--max-iterations N` | Max agent iterations (default: 50, max: 1000) |
 | `--no-skills` | Disable skill discovery |
 | `--skills-path PATH` | Add custom skills search path |
+| `--no-agents-md` | Disable AGENTS.md discovery |
 
 ### YOLO Mode
 

--- a/tools/agent/agent-loop.cpp
+++ b/tools/agent/agent-loop.cpp
@@ -169,6 +169,25 @@ All tests passing now.
 
 When the task is complete, provide a brief summary of what you did.)";
 
+    // Append AGENTS.md section if available (agents.md spec)
+    if (!config.agents_md_prompt_section.empty()) {
+        system_prompt += R"(
+
+# Project Context
+
+This project has AGENTS.md files with specific guidance for this codebase.
+Follow these project-specific instructions, especially for:
+- Build and test commands
+- Code style preferences
+- File organization conventions
+- PR and commit guidelines
+
+When project instructions conflict with general guidelines, prefer project-specific guidance.
+
+)";
+        system_prompt += config.agents_md_prompt_section;
+    }
+
     // Append skills section if available (agentskills.io spec)
     if (!config.skills_prompt_section.empty()) {
         system_prompt += R"(

--- a/tools/agent/agent-loop.h
+++ b/tools/agent/agent-loop.h
@@ -35,6 +35,10 @@ struct agent_config {
     bool enable_skills = true;
     std::vector<std::string> skills_search_paths;  // Additional search paths
     std::string skills_prompt_section;             // Pre-generated XML for prompt injection
+
+    // AGENTS.md configuration (agents.md spec)
+    bool enable_agents_md = true;
+    std::string agents_md_prompt_section;          // Pre-generated XML for prompt injection
 };
 
 // Result from running the agent loop

--- a/tools/agent/agents-md/agents-md-manager.cpp
+++ b/tools/agent/agents-md/agents-md-manager.cpp
@@ -1,0 +1,183 @@
+#include "agents-md-manager.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+std::string agents_md_manager::escape_xml_attr(const std::string & str) {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        switch (c) {
+            case '&':  result += "&amp;";  break;
+            case '<':  result += "&lt;";   break;
+            case '>':  result += "&gt;";   break;
+            case '"':  result += "&quot;"; break;
+            case '\'': result += "&apos;"; break;
+            default:   result += c;        break;
+        }
+    }
+    return result;
+}
+
+std::string agents_md_manager::find_git_root(const std::string & start_dir) {
+    try {
+        fs::path current = fs::absolute(start_dir);
+
+        // Walk up until we find .git or hit root
+        while (!current.empty() && current.has_parent_path()) {
+            fs::path git_dir = current / ".git";
+            if (fs::exists(git_dir)) {
+                return current.string();
+            }
+
+            fs::path parent = current.parent_path();
+            if (parent == current) {
+                break;  // Reached filesystem root
+            }
+            current = parent;
+        }
+    } catch (const fs::filesystem_error &) {
+        // Ignore errors, return empty
+    }
+
+    return "";
+}
+
+std::optional<std::string> agents_md_manager::read_file(const std::string & path) {
+    try {
+        std::ifstream file(path, std::ios::binary);
+        if (!file) {
+            return std::nullopt;
+        }
+
+        // Read content
+        std::ostringstream buffer;
+        buffer << file.rdbuf();
+        std::string content = buffer.str();
+
+        // Check for binary content (null bytes in first 8KB)
+        size_t check_size = std::min(content.size(), size_t(8192));
+        if (content.substr(0, check_size).find('\0') != std::string::npos) {
+            return std::nullopt;  // Binary file
+        }
+
+        return content;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+int agents_md_manager::discover(const std::string & working_dir) {
+    return discover(working_dir, "");
+}
+
+int agents_md_manager::discover(const std::string & working_dir, const std::string & config_dir) {
+    files_.clear();
+
+    try {
+        fs::path current = fs::absolute(working_dir);
+        std::string git_root = find_git_root(working_dir);
+        fs::path stop_at = git_root.empty() ? current : fs::path(git_root);
+
+        int depth = 0;
+        const int max_depth = 100;  // Sanity limit
+
+        // Walk from working dir up to git root (or just working dir if not in git)
+        while (depth < max_depth) {
+            // Check for AGENTS.md in current directory
+            fs::path agents_path = current / "AGENTS.md";
+
+            if (fs::exists(agents_path) && fs::is_regular_file(agents_path)) {
+                auto content = read_file(agents_path.string());
+                if (content && !content->empty()) {
+                    agents_md_file file;
+                    file.path = fs::absolute(agents_path).string();
+                    file.content = *content;
+                    file.depth = depth;
+
+                    // Compute relative path from git root or working dir
+                    if (!git_root.empty()) {
+                        file.relative_path = fs::relative(agents_path, git_root).string();
+                    } else {
+                        file.relative_path = "AGENTS.md";
+                    }
+
+                    files_.push_back(file);
+                }
+            }
+
+            // Stop if we've reached git root or filesystem root
+            if (current == stop_at) {
+                break;
+            }
+
+            fs::path parent = current.parent_path();
+            if (parent == current) {
+                break;  // Reached filesystem root
+            }
+
+            current = parent;
+            depth++;
+        }
+
+        // Check for global AGENTS.md in config directory (lowest precedence)
+        if (!config_dir.empty()) {
+            fs::path global_agents = fs::path(config_dir) / "AGENTS.md";
+            if (fs::exists(global_agents) && fs::is_regular_file(global_agents)) {
+                auto content = read_file(global_agents.string());
+                if (content && !content->empty()) {
+                    agents_md_file file;
+                    file.path = fs::absolute(global_agents).string();
+                    file.content = *content;
+                    file.depth = depth + 1;  // Lower precedence than any project file
+                    file.relative_path = "(global)";
+                    files_.push_back(file);
+                }
+            }
+        }
+    } catch (const fs::filesystem_error &) {
+        // Ignore filesystem errors
+    }
+
+    // Files are already in order (closest first, global last)
+    return static_cast<int>(files_.size());
+}
+
+size_t agents_md_manager::total_content_size() const {
+    size_t total = 0;
+    for (const auto & file : files_) {
+        total += file.content.size();
+    }
+    return total;
+}
+
+std::string agents_md_manager::generate_prompt_section() const {
+    if (files_.empty()) {
+        return "";
+    }
+
+    std::ostringstream xml;
+    xml << "<project_context>\n";
+    xml << "Project guidance from AGENTS.md files (closest to working directory takes precedence):\n\n";
+
+    for (const auto & file : files_) {
+        xml << "<agents_md path=\"" << escape_xml_attr(file.relative_path) << "\"";
+        if (file.depth == 0) {
+            xml << " precedence=\"highest\"";
+        }
+        xml << ">\n";
+        xml << file.content;
+        // Ensure content ends with newline
+        if (!file.content.empty() && file.content.back() != '\n') {
+            xml << "\n";
+        }
+        xml << "</agents_md>\n\n";
+    }
+
+    xml << "</project_context>";
+    return xml.str();
+}

--- a/tools/agent/agents-md/agents-md-manager.h
+++ b/tools/agent/agents-md/agents-md-manager.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+// Represents a discovered AGENTS.md file
+struct agents_md_file {
+    std::string path;           // Absolute path to the file
+    std::string content;        // Raw markdown content
+    std::string relative_path;  // Path relative to git root (for display)
+    int depth;                  // Distance from working dir (0 = working dir)
+};
+
+// Manages AGENTS.md discovery and prompt generation
+// Implements agents.md specification (https://agents.md/)
+class agents_md_manager {
+public:
+    // Discover AGENTS.md files starting from working_dir up to git root
+    // Optionally includes global AGENTS.md from config_dir (lowest precedence)
+    // Returns number of files discovered
+    int discover(const std::string & working_dir);
+    int discover(const std::string & working_dir, const std::string & config_dir);
+
+    // Get all discovered files (ordered by depth, closest first)
+    const std::vector<agents_md_file> & get_files() const { return files_; }
+
+    // Generate XML section for system prompt injection
+    // Returns empty string if no files discovered
+    std::string generate_prompt_section() const;
+
+    // Get total content size (for logging/debugging)
+    size_t total_content_size() const;
+
+    // Check if any files were discovered
+    bool has_files() const { return !files_.empty(); }
+
+private:
+    std::vector<agents_md_file> files_;
+
+    // Find git root from a starting directory
+    // Returns empty string if not in a git repository
+    static std::string find_git_root(const std::string & start_dir);
+
+    // Read file content safely
+    // Returns nullopt if file cannot be read or is binary
+    static std::optional<std::string> read_file(const std::string & path);
+
+    // Escape XML special characters in attributes
+    static std::string escape_xml_attr(const std::string & str);
+};


### PR DESCRIPTION
## Summary

Add support for the [AGENTS.md](https://agents.md/) specification, which provides project-specific guidance to AI coding assistants.

- Discovers AGENTS.md files from working directory up to git root
- Supports global `~/.config/llama-agent/AGENTS.md` (lowest precedence)
- Injects content into system prompt with precedence markers
- New `--no-agents-md` flag to disable discovery
- New `/agents` command to list discovered files

## Discovery Precedence (highest to lowest)

1. `./AGENTS.md` - Working directory
2. `../AGENTS.md`, `../../AGENTS.md`, ... - Parent directories up to git root
3. `~/.config/llama-agent/AGENTS.md` - Global user preferences

## Test plan

- [ ] Create AGENTS.md in a project, verify it's loaded at startup
- [ ] Test monorepo with nested AGENTS.md files
- [ ] Test global AGENTS.md in ~/.config/llama-agent/
- [ ] Verify `/agents` command shows discovered files
- [ ] Verify `--no-agents-md` disables discovery