### PR TITLE
chore: change config dir from ~/.config/llama-agent to ~/.llama-agent

### DIFF
--- a/tools/agent/README.md
+++ b/tools/agent/README.md
@@ -91,8 +91,8 @@ Skills are reusable prompt modules that extend the agent's capabilities. They fo
 Skills are directories containing a `SKILL.md` file with YAML frontmatter:
 
 ```bash
-mkdir -p ~/.config/llama-agent/skills/code-review
-cat > ~/.config/llama-agent/skills/code-review/SKILL.md << 'EOF'
+mkdir -p ~/.llama-agent/skills/code-review
+cat > ~/.llama-agent/skills/code-review/SKILL.md << 'EOF'
 ---
 name: code-review
 description: Review code for bugs, security issues, and improvements. Use when asked to review code or a PR.
@@ -138,7 +138,7 @@ Markdown instructions for the agent...
 Skills are discovered from (in priority order):
 
 1. `./.llama-agent/skills/` - Project-local skills
-2. `~/.config/llama-agent/skills/` - User-global skills
+2. `~/.llama-agent/skills/` - User-global skills
 3. Custom paths via `--skills-path`
 
 ### CLI Options
@@ -170,7 +170,7 @@ The agent automatically discovers and loads [AGENTS.md](https://agents.md) files
 
 1. `./AGENTS.md` - Current working directory (highest precedence)
 2. `../AGENTS.md`, `../../AGENTS.md`, ... - Parent directories up to git root
-3. `~/.config/llama-agent/AGENTS.md` - Global user preferences (lowest precedence)
+3. `~/.llama-agent/AGENTS.md` - Global user preferences (lowest precedence)
 
 ### Creating an AGENTS.md File
 
@@ -220,7 +220,7 @@ The agent supports [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ### Configuration
 
-Create an `mcp.json` file in your working directory or at `~/.config/llama-agent/mcp.json`:
+Create an `mcp.json` file in your working directory or at `~/.llama-agent/mcp.json`:
 
 ```json
 {

--- a/tools/agent/agent.cpp
+++ b/tools/agent/agent.cpp
@@ -42,13 +42,9 @@ static std::string get_config_dir() {
     }
     return "";
 #else
-    const char * xdg_config = std::getenv("XDG_CONFIG_HOME");
-    if (xdg_config) {
-        return std::string(xdg_config) + "/llama-agent";
-    }
     const char * home = std::getenv("HOME");
     if (home) {
-        return std::string(home) + "/.config/llama-agent";
+        return std::string(home) + "/.llama-agent";
     }
     return "";
 #endif
@@ -276,7 +272,7 @@ int main(int argc, char ** argv) {
     agents_md_manager agents_md_mgr;
     int agents_md_count = 0;
     if (enable_agents_md) {
-        // Pass config_dir for global AGENTS.md support (~/.config/llama-agent/AGENTS.md)
+        // Pass config_dir for global AGENTS.md support (~/.llama-agent/AGENTS.md)
         std::string agents_config_dir = get_config_dir();
         agents_md_count = agents_md_mgr.discover(working_dir, agents_config_dir);
 
@@ -420,7 +416,7 @@ int main(int argc, char ** argv) {
                     console::log("\nNo skills discovered.\n");
                     console::log("Skills are loaded from:\n");
                     console::log("  ./.llama-agent/skills/  (project-local)\n");
-                    console::log("  ~/.config/llama-agent/skills/  (user-global)\n");
+                    console::log("  ~/.llama-agent/skills/  (user-global)\n");
                 } else {
                     console::log("\nAvailable skills:\n");
                     for (const auto & skill : skills) {
@@ -437,7 +433,7 @@ int main(int argc, char ** argv) {
                     console::log("\nNo AGENTS.md files discovered.\n");
                     console::log("AGENTS.md files are searched from:\n");
                     console::log("  ./AGENTS.md to git root  (project-specific)\n");
-                    console::log("  ~/.config/llama-agent/AGENTS.md  (global)\n");
+                    console::log("  ~/.llama-agent/AGENTS.md  (global)\n");
                 } else {
                     console::log("\nDiscovered AGENTS.md files (closest first):\n");
                     for (const auto & file : files) {

--- a/tools/agent/mcp/mcp-server-manager.cpp
+++ b/tools/agent/mcp/mcp-server-manager.cpp
@@ -237,7 +237,7 @@ std::string find_mcp_config(const std::string & working_dir) {
     // Then check user config directory
     const char * home = std::getenv("HOME");
     if (home) {
-        fs::path user_config = fs::path(home) / ".config" / "llama-agent" / "mcp.json";
+        fs::path user_config = fs::path(home) / ".llama-agent" / "mcp.json";
         if (fs::exists(user_config)) {
             return user_config.string();
         }

--- a/tools/agent/mcp/mcp-server-manager.h
+++ b/tools/agent/mcp/mcp-server-manager.h
@@ -67,5 +67,5 @@ private:
 };
 
 // Find MCP config file
-// Checks: ./mcp.json, then ~/.config/llama-agent/mcp.json
+// Checks: ./mcp.json, then ~/.llama-agent/mcp.json
 std::string find_mcp_config(const std::string & working_dir);


### PR DESCRIPTION
## Summary

- Change global config directory from `~/.config/llama-agent/` to `~/.llama-agent/`
- Follow convention used by Claude Code (`~/.claude/`) and OpenAI Codex (`~/.codex/`)
- Remove XDG_CONFIG_HOME fallback for simpler, consistent behavior

## Changes

- `agent.cpp`: Update `get_config_dir()` to return `~/.llama-agent`
- `mcp-server-manager.cpp`: Update MCP config file search path
- `mcp-server-manager.h`: Update comment
- `README.md`: Update all documentation references (5 occurrences)

## Migration

Users with existing configs should move their directory:
```bash
mv ~/.config/llama-agent ~/.llama-agent
```