### PR TITLE
feat(agent): add /stats command for token usage tracking

### DIFF
--- a/tools/agent/agent-loop.cpp
+++ b/tools/agent/agent-loop.cpp
@@ -681,6 +681,19 @@ agent_loop_result agent_loop::run(const std::string & user_prompt) {
         result_timings timings;
         common_chat_msg parsed = generate_completion(timings);
 
+        // Accumulate session statistics
+        if (timings.prompt_n > 0) {
+            stats_.total_input += timings.prompt_n;
+            stats_.total_prompt_ms += timings.prompt_ms;
+        }
+        if (timings.predicted_n > 0) {
+            stats_.total_output += timings.predicted_n;
+            stats_.total_predicted_ms += timings.predicted_ms;
+        }
+        if (timings.cache_n > 0) {
+            stats_.total_cached += timings.cache_n;
+        }
+
         if (parsed.content.empty() && parsed.tool_calls.empty() && is_interrupted_.load()) {
             result.stop_reason = agent_stop_reason::USER_CANCELLED;
             return result;

--- a/tools/agent/agent-loop.h
+++ b/tools/agent/agent-loop.h
@@ -48,6 +48,15 @@ struct agent_loop_result {
     int iterations = 0;
 };
 
+// Session-level statistics for token tracking
+struct session_stats {
+    int32_t total_input = 0;       // Total prompt tokens processed
+    int32_t total_output = 0;      // Total tokens generated
+    int32_t total_cached = 0;      // Total tokens served from KV cache
+    double total_prompt_ms = 0;    // Total prompt evaluation time
+    double total_predicted_ms = 0; // Total generation time
+};
+
 // The main agent loop class
 class agent_loop {
 public:
@@ -64,6 +73,9 @@ public:
 
     // Get current messages (for debugging)
     const json & get_messages() const { return messages_; }
+
+    // Get session statistics
+    const session_stats & get_stats() const { return stats_; }
 
 private:
     // Generate a completion and get the parsed response with tool calls
@@ -85,4 +97,5 @@ private:
     task_params task_defaults_;
     permission_manager permission_mgr_;
     tool_context tool_ctx_;
+    session_stats stats_;
 };

--- a/tools/agent/agent.cpp
+++ b/tools/agent/agent.cpp
@@ -342,6 +342,7 @@ int main(int argc, char ** argv) {
         console::log("commands:\n");
         console::log("  /exit       exit the agent\n");
         console::log("  /clear      clear conversation history\n");
+        console::log("  /stats      show token usage statistics\n");
         console::log("  /tools      list available tools\n");
         console::log("  /skills     list available skills\n");
         console::log("  /agents     list discovered AGENTS.md files\n");
@@ -406,6 +407,25 @@ int main(int argc, char ** argv) {
                 for (const auto * tool : tool_registry::instance().get_all_tools()) {
                     console::log("  %s:\n", tool->name.c_str());
                     console::log("    %s\n", tool->description.c_str());
+                }
+                continue;
+            }
+            if (buffer == "/stats") {
+                const auto & stats = agent.get_stats();
+                console::log("\nSession Statistics:\n");
+                console::log("  Prompt tokens:  %d\n", stats.total_input);
+                console::log("  Output tokens:  %d\n", stats.total_output);
+                if (stats.total_cached > 0) {
+                    console::log("  Cached tokens:  %d\n", stats.total_cached);
+                }
+                console::log("  Total tokens:   %d\n", stats.total_input + stats.total_output);
+                if (stats.total_prompt_ms > 0) {
+                    console::log("  Prompt time:    %.2fs\n", stats.total_prompt_ms / 1000.0);
+                }
+                if (stats.total_predicted_ms > 0) {
+                    console::log("  Gen time:       %.2fs\n", stats.total_predicted_ms / 1000.0);
+                    double avg_speed = stats.total_output * 1000.0 / stats.total_predicted_ms;
+                    console::log("  Avg speed:      %.1f tok/s\n", avg_speed);
                 }
                 continue;
             }


### PR DESCRIPTION
## Summary
- Add `session_stats` struct to track cumulative token usage across completions
- Track prompt tokens, output tokens, cached tokens, and timing data
- Add `/stats` slash command to display session statistics

## Test plan
- [ ] Run llama-agent and interact with it
- [ ] Use `/stats` to verify token counts are accumulated correctly
- [ ] Verify cached token tracking when KV cache is enabled