### PR TITLE
agent: make subagents opt-in via --subagents flag

### DIFF
--- a/tools/agent/README.md
+++ b/tools/agent/README.md
@@ -93,6 +93,12 @@ llama-agent -hf unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Q5_K_M
 
 Subagents are specialized child agents that handle complex tasks independently, keeping the main conversation context clean and efficient.
 
+| Flag | Description |
+|------|-------------|
+| `--subagents` | Enable subagents (disabled by default) |
+| `--max-subagent-depth N` | Set max nesting depth (0-5, default: 1 when enabled) |
+| `--no-subagents` | Explicitly disable subagents |
+
 ### Why Subagents?
 
 Without subagents, every file read and search pollutes your main context. With subagents, only a summary enters main context—the detailed exploration is discarded afterward.

--- a/tools/agent/agent.cpp
+++ b/tools/agent/agent.cpp
@@ -108,7 +108,7 @@ int main(int argc, char ** argv) {
     bool enable_skills = true;
     bool enable_agents_md = true;
     std::vector<std::string> extra_skills_paths;
-    int max_subagent_depth = 1;  // Default: allow 1 level of subagent nesting
+    int max_subagent_depth = 0;  // Default: subagents disabled (use --subagents to enable)
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -191,6 +191,14 @@ int main(int argc, char ** argv) {
             }
         } else if (arg == "--no-subagents") {
             max_subagent_depth = 0;
+            // Remove from argv
+            for (int j = i; j < argc - 1; j++) {
+                argv[j] = argv[j + 1];
+            }
+            argc--;
+            i--;  // Re-check this position
+        } else if (arg == "--subagents") {
+            max_subagent_depth = 1;
             // Remove from argv
             for (int j = i; j < argc - 1; j++) {
                 argv[j] = argv[j + 1];

--- a/tools/agent/subagent/subagent-display.h
+++ b/tools/agent/subagent/subagent-display.h
@@ -69,7 +69,7 @@ private:
 
     std::mutex mtx_;
     std::atomic<int> depth_{0};
-    int max_depth_ = 1;
+    int max_depth_ = 0;  // Default: subagents disabled
 
     // Print tree characters for current depth
     // If buffer is provided, output goes to buffer; otherwise to console


### PR DESCRIPTION
## Summary
- Subagents (task tool) are now disabled by default
- Added `--subagents` flag to enable them
- `--max-subagent-depth N` still works for custom nesting depth
- Updated README with new flags documentation

## Changes
- `tools/agent/agent.cpp`: Default `max_subagent_depth` changed from 1 to 0, added `--subagents` flag
- `tools/agent/server/agent-server.cpp`: Added same flag support for HTTP API server
- `tools/agent/subagent/subagent-display.h`: Default `max_depth_` changed from 1 to 0
- `tools/agent/README.md`: Added flags table to Subagents section

## Test plan
- [ ] Run `llama-agent` without flags → task tool should be unavailable
- [ ] Run `llama-agent --subagents` → task tool should work
- [ ] Run `llama-agent --max-subagent-depth 2` → task tool should work with depth 2