### PR TITLE
Add missing permission-async.cpp to llama-agent target

### DIFF
--- a/tools/agent/CMakeLists.txt
+++ b/tools/agent/CMakeLists.txt
@@ -5,6 +5,7 @@ set(AGENT_SOURCES
     agent-loop.cpp
     tool-registry.cpp
     permission.cpp
+    permission-async.cpp
     skills/skills-manager.cpp
     agents-md/agents-md-manager.cpp
     subagent/subagent-types.cpp


### PR DESCRIPTION
Fixes compilation issues for the llama-agent target where it fails with missing symbols for `permission_manager_async` by adding the implementation file to the target.